### PR TITLE
Binlogs -> install

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -121,8 +121,8 @@ class mysql::server (
   Class['mysql::server::root_password'] -> Mysql::Db <| |>
 
   include '::mysql::server::config'
-  include '::mysql::server::install'
   include '::mysql::server::binarylog'
+  include '::mysql::server::install'
   include '::mysql::server::installdb'
   include '::mysql::server::service'
   include '::mysql::server::root_password'


### PR DESCRIPTION
When installing on Debian based distribution mysql will try to start and fail because the binlog directory is not present.